### PR TITLE
Curtailed article input when long

### DIFF
--- a/src/askademic/tools.py
+++ b/src/askademic/tools.py
@@ -164,6 +164,9 @@ def get_article(url: str, max_attempts: int = 10) -> str:
             time.sleep(60)
             attempts += 1
 
+    # curtail the article to 100k characters (there can be books, too long)
+    article = article[:100000]
+
     article = f"""
         -------{url}------------
         {article}

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from askademic.tools import identify_latest_day
+from askademic.tools import get_article, identify_latest_day
 from askademic.utils import get_arxiv_categories
 
 
@@ -87,3 +87,43 @@ def test_identify_latest_day_error(mock_requests_get):
         "http://export.arxiv.org/api/query?search_query=cat:cs.AI&start=0&max_results=1&sortBy=submittedDate&sortOrder=descending",
         timeout=360,
     )
+
+    @patch("askademic.tools.requests.get")
+    @patch("askademic.tools.pymupdf.open")
+    def test_get_article_success(mock_pymupdf_open, mock_requests_get):
+        # Mock the response from requests.get
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.content = b"mock pdf content"
+        mock_requests_get.return_value = mock_response
+
+        # Mock the pymupdf.open behavior
+        mock_doc = MagicMock()
+        mock_doc.__enter__.return_value = mock_doc
+        mock_doc.__exit__.return_value = None
+        mock_doc.pages = [MagicMock(get_text=MagicMock(return_value="Page 1 content"))]
+        mock_pymupdf_open.return_value = mock_doc
+
+        result = get_article("http://example.com/mock.pdf")
+
+        assert "Page 1 content" in result
+        mock_requests_get.assert_called_once_with(
+            "http://example.com/mock.pdf", timeout=360
+        )
+        mock_pymupdf_open.assert_called_once()
+
+
+def test_get_article_():
+
+    article = get_article("http://arxiv.org/pdf/1604.06737v1")
+
+    assert "Unlike unstructured data found in nature," in article
+    assert "------END----------------" in article
+
+
+def test_get_article_is_curtailed():
+
+    # a book
+    article = get_article("http://arxiv.org/pdf/1302.6946")
+
+    assert len(article) == 100106  # max len + added wrapping chars


### PR DESCRIPTION
Berna ho ridotto solo input quando troppo lungo, con un cutoff sperimentale - ho usato i libri menzionati [qui](https://math.stackexchange.com/questions/844936/textbooks-lecture-notes-and-articles-from-arxiv-for-undergraduate-students) e un po' di articoli. 

Questo si riferisce a #21 ma non ho tolto la parte di references dei paper - probabilmente succede raramente che ci sono un sacco di refs e ho paura che scasini i risultati se poi l'LLM non trova la referenza alla referenza nel testo?