### PR TITLE
fix(summarizer): json output explicitly stated in the prompt

### DIFF
--- a/src/askademic/prompts.py
+++ b/src/askademic/prompts.py
@@ -182,6 +182,13 @@ USER_PROMPT_SUMMARY_TEMPLATE = cleandoc(
     Generate a global summary of all that has been published.
     Identify the topics covered in a clear and easy-to-understand way.
     Describe each topic in a few sentences, citing the articles you used to define it.
+    The output should be a JSON object with the following fields:
+    {{
+        "category": "The category of the articles.",
+        "last_published_day": "The latest day of publications available on the API.",
+        "summary": "Global summary of all abstracts, identifying topics.",
+        "recent_papers_url": "arXiv URL to the most recent papers in the chosen category",
+    }}
     """
 )
 


### PR DESCRIPTION
This is actually for issue #99  but the question was in issue #79. The problem was mainly due to  GEMINI not being able to generate the correct output format for pydantic-ai. If you state what json format you want in the output it works,

Here is the answer to the question:

![image](https://github.com/user-attachments/assets/653934d0-e5db-40a9-bb15-4eb24415b5b6)


it is off topic and not in italian, so we did not exactly solves the issue, but at least it provides an answer. Maybe it should specific that the answer is off-topic?