### PR TITLE
fix(tools): search by title and by abs sorting by relevance only

### DIFF
--- a/src/askademic/local_testing.py
+++ b/src/askademic/local_testing.py
@@ -42,7 +42,7 @@ async def main():
                     usage_limits=UsageLimits(request_limit=20),  # limit to 10 requests
                 )
 
-                if allower.data.is_scientific:
+                if allower.output.is_scientific:
                     result = await orchestrator_agent.run(
                         question,
                         usage_limits=UsageLimits(

--- a/src/askademic/tools.py
+++ b/src/askademic/tools.py
@@ -107,7 +107,7 @@ def search_articles(
 
 def search_articles_by_abs(
     query: str = "lyapunov exponents",
-    sortby: str = "submittedDate",
+    sortby: str = "relevance",
     start: int = 0,
     max_results: int = 20,
 ):
@@ -122,17 +122,13 @@ def search_articles_by_abs(
     - summary: a summary of the article's content
     Args:
         query: the query used for the search
-        sortby: how to sort the results. Possible values:
-            - relevance (most relevant on the top)
-            - lastUpdatedDate (most recently updated on the top)
-            - submittedDate (most recently submitted on top)
         start: the index of the ranking where the table starts, add +20 to get the next table chunk
         max_results: the total number of articles to retrieve. The default value is 20.
     """
 
     return search_articles(
         query=query,
-        sortby=sortby,
+        sortby="relevance",
         prefix="abs",
         start=start,
         max_results=max_results,
@@ -141,7 +137,6 @@ def search_articles_by_abs(
 
 def search_articles_by_title(
     query: str = "lyapunov exponents",
-    sortby: str = "submittedDate",
     start: int = 0,
     max_results: int = 20,
 ):
@@ -155,17 +150,13 @@ def search_articles_by_title(
     - summary: a summary of the article's content
     Args:
         query: the query used for the search
-        sortby: how to sort the results. Possible values:
-            - relevance (most relevant on the top)
-            - lastUpdatedDate (most recently updated on the top)
-            - submittedDate (most recently submitted on top)
         start: the index of the ranking where the table starts, add +20 to get the next table chunk
         max_results: the total number of articles to retrieve. The default value is 20.
     """
 
     return search_articles(
         query=query,
-        sortby=sortby,
+        sortby="relevance",
         prefix="ti",
         start=start,
         max_results=max_results,


### PR DESCRIPTION
it was easy, I am forcing the LLM to search only by relevance, probably it was overflown by irrelevant articles and did not know what to pick.

This is the answer now:

response: One effective method for assessing treatment effects in threshold-based assignment experiments involves a differencing and matching-based estimator, as 
described in the paper 'Estimation and Inference for the Average Treatment Effect in a Score-Explained Heterogeneous Treatment Effect Model' . This approach addresses 
the limitations of traditional methods that focus solely on observations near the cutoff point, potentially leading to information loss and non-parametric convergence 
rates. The proposed estimator utilizes all available observations and accounts for heterogeneous treatment effects. The method involves a two-step process: first, 
approximating the unobserved confounders using regression residuals, and second, employing a residual matching technique to estimate the average treatment effect on 
the treated (ATT). The paper establishes the asymptotic normality of the estimator and demonstrates its effectiveness through synthetic and real data analyses. 
Additionally, the method yields non-parametric estimates of the conditional average treatment effect (CATE) and individual treatment effect (ITE) as a byproduct.
article_list: ['http://arxiv.org/pdf/2504.17126v1']


not the best but at least it gives one and the question agent is still "an agent"